### PR TITLE
Update templates for dartapi_core 0.3.0 — token pairs, refresh rotation, dual revocation (v0.1.52)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 0.1.52
+
+- Update generated projects to `dartapi_core ^0.3.0` (secure token revocation and refresh rotation):
+  - `auth_service.dart.tmpl`: login and refresh now issue tokens via `JwtService.generateTokenPair` — the deprecated `generateRefreshToken(accessToken: ...)` (removal planned for `dartapi_core` 0.4.0) is no longer used.
+  - Refresh endpoint returns a **full new token pair**: refresh tokens are single-use when a `TokenStore` is configured (`verifyRefreshToken` consumes them atomically), so the old token can no longer be re-issued unchanged.
+  - Logout revokes **both** the access token and (when sent in the request body as `{"refreshToken": "..."}`) the refresh token; `revokeToken` now verifies the token signature and returns `Future<bool>`.
+  - Wire the new `JwtService.onRefreshTokenReuse` callback in `bootstrap.dart.tmpl` and the generated `main.dart` with a comment explaining it fires when an already-consumed refresh token is presented again (token-theft signal).
+  - `TokenStore` is now a base class: comments in generated code explain to **extend** it (not implement), that `revoke()` gained a `{Duration? ttl}` parameter, and that distributed backends should override `revokeIfActive` with an atomic operation (e.g. Redis `SET NX EX`).
+  - Generated auth tests: `JwtService` is constructed with an `InMemoryTokenStore` (required for revocation and rotation), refresh tests assert a rotated (different) refresh token and that reuse of a consumed token throws 401, and logout tests cover revoking both tokens.
+- Use new `dartapi_core` APIs in generated projects:
+  - `app.configureLogging(format: LogFormat.json, excludePaths: [...])` — structured JSON request logs with health/metrics probes excluded.
+  - `app.start(address: '0.0.0.0', ...)` — bind address is now explicit/configurable, with a comment pointing at `await app.stop()` for graceful programmatic shutdown.
+- Generated README documents the rotated refresh response, single-use semantics, and that invalid/missing tokens receive `401` with a `WWW-Authenticate: Bearer` header (was `403` before `dartapi_core` 0.2.0).
+
 ## 0.1.51
 
 - Fix `--full` generated projects: add `import 'package:shelf/shelf.dart'` to `auth_controller.dart`, `files_controller.dart`, `notifications_controller.dart`, `product_controller.dart`, `stats_controller.dart`, and `user_controller.dart` templates — `Request` and `Response` are not re-exported by `dartapi_core`, causing undefined-class errors.

--- a/lib/constants/create_command_constants.dart
+++ b/lib/constants/create_command_constants.dart
@@ -232,12 +232,18 @@ class CreateCommandConstants {
     // dart:io needed for Platform.environment in _loadEnv(), generated for any feature.
     if (hasAny) buf.writeln("import 'dart:io';");
     if (hasAny) buf.writeln();
-    buf.writeln("import 'package:dartapi_core/dartapi_core.dart';");
+    // The project defines its own AppConfig subclass; hide the base one that
+    // the dartapi_core barrel exports to avoid an ambiguous_import error.
+    buf.writeln(hasAny
+        ? "import 'package:dartapi_core/dartapi_core.dart' hide AppConfig;"
+        : "import 'package:dartapi_core/dartapi_core.dart';");
     if (hasDb) buf.writeln("import 'package:dartapi_db/dartapi_db.dart';");
     buf.writeln();
+    // loadEnvFile/mergeEnv come from the dartapi_core import; the generated
+    // env_loader.dart only re-exports them, so importing it here would be
+    // flagged as unnecessary_import.
     if (hasAny) {
       buf.writeln("import 'package:$name/src/config/app_config.dart';");
-      buf.writeln("import 'package:$name/src/config/env_loader.dart';");
     }
     buf.writeln("import 'package:$name/src/controllers/hello_controller.dart';");
     if (hasAuth) {
@@ -274,6 +280,9 @@ class CreateCommandConstants {
 
     // Auth setup
     if (hasAuth) {
+      buf.writeln('  // InMemoryTokenStore keeps revoked JTIs in-process. For multi-instance');
+      buf.writeln('  // deployments, extend TokenStore with a Redis/database backend and');
+      buf.writeln('  // override revokeIfActive with an atomic op (e.g. Redis SET NX EX).');
       buf.writeln('  final tokenStore = InMemoryTokenStore();');
       buf.writeln('  final jwtService = JwtService(');
       buf.writeln('    accessTokenSecret: config.jwtAccessSecret,');
@@ -281,6 +290,14 @@ class CreateCommandConstants {
       buf.writeln("    issuer: '$name',");
       buf.writeln("    audience: '$name-users',");
       buf.writeln('    tokenStore: tokenStore,');
+      buf.writeln('    // Fires when an already-consumed refresh token is presented again —');
+      buf.writeln('    // the classic token-theft signal. Respond by terminating the whole');
+      buf.writeln("    // session, e.g. revoke all tokens for payload['sub'].");
+      buf.writeln('    onRefreshTokenReuse: (payload) async {');
+      buf.writeln('      // ignore: avoid_print');
+      buf.writeln(
+          r"      print('[security] refresh token reuse detected for sub=${payload['sub']}');");
+      buf.writeln('    },');
       buf.writeln('  );');
       buf.writeln('  final authService = AuthService(jwtService: jwtService);');
       buf.writeln();
@@ -317,6 +334,11 @@ class CreateCommandConstants {
       buf.writeln("  final app = DartAPI(appName: '$name');");
     }
     buf.writeln('  app.enableHealthCheck();');
+    buf.writeln('  // Structured JSON request logs; the /health probe is not logged.');
+    buf.writeln('  app.configureLogging(');
+    buf.writeln('    format: LogFormat.json,');
+    buf.writeln("    excludePaths: ['/health'],");
+    buf.writeln('  );');
     buf.writeln();
 
     // Controllers
@@ -347,7 +369,10 @@ class CreateCommandConstants {
       buf.writeln();
     }
 
-    buf.writeln('  await app.start(port: port);');
+    buf.writeln("  // `address` is configurable — e.g. '127.0.0.1' to bind loopback only.");
+    buf.writeln('  // For a graceful programmatic shutdown (tests, embedding), call');
+    buf.writeln('  // `await app.stop()`; SIGINT/SIGTERM are already handled by start().');
+    buf.writeln("  await app.start(port: port, address: '0.0.0.0');");
     buf.writeln('}');
 
     // ── Helpers ───────────────────────────────────────────────────────────────
@@ -388,7 +413,7 @@ class CreateCommandConstants {
     buf.writeln('  sdk: ^3.7.2');
     buf.writeln();
     buf.writeln('dependencies:');
-    buf.writeln('  dartapi_core: ^0.1.9');
+    buf.writeln('  dartapi_core: ^0.3.0');
     buf.writeln('  shelf: ^1.4.2');
     if (features.contains(Feature.db)) {
       buf.writeln('  dartapi_db: ^0.0.15');

--- a/lib/templates/auth_controller.dart.tmpl
+++ b/lib/templates/auth_controller.dart.tmpl
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:dartapi_core/dartapi_core.dart';
 import 'package:shelf/shelf.dart';
 import 'package:{{projectName}}/src/dto/login_dto.dart';
@@ -38,8 +40,10 @@ class AuthController extends BaseController {
         dtoParser: _RefreshRequest.fromJson,
         summary: 'Refresh token',
         description:
-            'Exchanges a valid refresh token for a new access token. '
-            'Send the refresh token in the JSON request body.',
+            'Exchanges a valid refresh token for a new access + refresh '
+            'token pair. Refresh tokens are single-use: the presented token '
+            'is consumed, so store and use the new refresh token from the '
+            'response. Send the refresh token in the JSON request body.',
         requestSchema: {
           'type': 'object',
           'required': ['refreshToken'],
@@ -58,8 +62,20 @@ class AuthController extends BaseController {
         middlewares: [authMiddleware(_jwtService)],
         summary: 'Logout',
         description:
-            'Revokes the current bearer token. All subsequent requests '
-            'that present this token will receive 401 Unauthorized.',
+            'Revokes the current bearer token, and optionally the refresh '
+            'token when one is sent in the JSON request body. All subsequent '
+            'requests that present a revoked token will receive '
+            '401 Unauthorized.',
+        requestSchema: {
+          'type': 'object',
+          'properties': {
+            'refreshToken': {
+              'type': 'string',
+              'description':
+                  'Optional — also revoke this refresh token on logout.',
+            },
+          },
+        },
         security: [SecurityScheme.bearer],
       );
 
@@ -74,7 +90,27 @@ class AuthController extends BaseController {
   Future<void> _logout(Request req, void _) async {
     final authHeader = req.header<String>('authorization') ?? '';
     if (!authHeader.startsWith('Bearer ')) return;
-    await _authService.logout(authHeader.substring(7));
+
+    // The body is optional: send {"refreshToken": "..."} to revoke the
+    // refresh token together with the access token.
+    String? refreshToken;
+    final body = await req.readAsString();
+    if (body.isNotEmpty) {
+      try {
+        final decoded = jsonDecode(body);
+        if (decoded is Map<String, dynamic> &&
+            decoded['refreshToken'] is String) {
+          refreshToken = decoded['refreshToken'] as String;
+        }
+      } on FormatException {
+        // Malformed body — still revoke the access token below.
+      }
+    }
+
+    await _authService.logout(
+      accessToken: authHeader.substring(7),
+      refreshToken: refreshToken,
+    );
   }
 }
 

--- a/lib/templates/auth_controller_test.dart.tmpl
+++ b/lib/templates/auth_controller_test.dart.tmpl
@@ -8,11 +8,14 @@ void main() {
   late AuthService authService;
 
   setUp(() {
+    // A TokenStore is required for revocation (logout) and for single-use
+    // refresh-token rotation.
     jwtService = JwtService(
       accessTokenSecret: 'test-access-secret-32-chars-long!!',
       refreshTokenSecret: 'test-refresh-secret-32-chars-long!',
       issuer: 'test',
       audience: 'test-users',
+      tokenStore: InMemoryTokenStore(),
     );
     authService = AuthService(jwtService: jwtService);
   });
@@ -46,12 +49,31 @@ void main() {
     });
 
     group('refresh', () {
-      test('valid refresh token returns a new access token', () async {
+      test('valid refresh token returns a full new token pair', () async {
         final tokens = authService.login(
             LoginDTO(username: 'admin@example.com', password: 'password'));
         final refreshed = await authService.refresh(tokens.refreshToken);
         expect(refreshed.accessToken, isNotEmpty);
-        expect(refreshed.refreshToken, equals(tokens.refreshToken));
+        expect(refreshed.refreshToken, isNotEmpty);
+        // Rotation: a new refresh token is issued on every refresh.
+        expect(refreshed.refreshToken, isNot(equals(tokens.refreshToken)));
+      });
+
+      test('refresh tokens are single-use — reuse throws 401', () async {
+        final tokens = authService.login(
+            LoginDTO(username: 'admin@example.com', password: 'password'));
+
+        // First use succeeds and consumes the token...
+        await authService.refresh(tokens.refreshToken);
+
+        // ...so a second use of the same token is rejected.
+        expect(
+          () => authService.refresh(tokens.refreshToken),
+          throwsA(
+            isA<ApiException>()
+                .having((e) => e.statusCode, 'statusCode', 401),
+          ),
+        );
       });
 
       test('invalid refresh token throws 401', () async {
@@ -71,7 +93,7 @@ void main() {
             LoginDTO(username: 'admin@example.com', password: 'password'));
 
         // Revoke the token
-        await authService.logout(tokens.accessToken);
+        await authService.logout(accessToken: tokens.accessToken);
 
         // A revoked token should fail verification
         final payload =
@@ -79,11 +101,25 @@ void main() {
         expect(payload, isNull);
       });
 
+      test('logout also revokes the refresh token when provided', () async {
+        final tokens = authService.login(
+            LoginDTO(username: 'admin@example.com', password: 'password'));
+
+        await authService.logout(
+          accessToken: tokens.accessToken,
+          refreshToken: tokens.refreshToken,
+        );
+
+        final payload =
+            await jwtService.verifyRefreshToken(tokens.refreshToken);
+        expect(payload, isNull);
+      });
+
       test('logout does not throw for a valid token', () async {
         final tokens = authService.login(
             LoginDTO(username: 'admin@example.com', password: 'password'));
         await expectLater(
-          authService.logout(tokens.accessToken),
+          authService.logout(accessToken: tokens.accessToken),
           completes,
         );
       });

--- a/lib/templates/auth_service.dart.tmpl
+++ b/lib/templates/auth_service.dart.tmpl
@@ -22,24 +22,30 @@ class AuthService {
       throw const ApiException(401, 'Invalid credentials');
     }
 
-    final accessToken = _jwtService.generateAccessToken(
+    final pair = _jwtService.generateTokenPair(
       claims: {'sub': 'user-1', 'email': dto.username, 'role': 'admin'},
     );
-    final refreshToken =
-        _jwtService.generateRefreshToken(accessToken: accessToken);
 
-    return TokenResponse(accessToken: accessToken, refreshToken: refreshToken);
+    return TokenResponse(
+      accessToken: pair.accessToken,
+      refreshToken: pair.refreshToken,
+    );
   }
 
-  /// Exchanges a valid refresh token for a new access token.
-  /// The refresh token itself is re-issued unchanged (rotation is optional).
+  /// Exchanges a valid refresh token for a full new access + refresh pair.
+  ///
+  /// Refresh tokens are single-use (rotation): [JwtService.verifyRefreshToken]
+  /// atomically consumes the presented token via the configured [TokenStore],
+  /// so the client MUST store and use the new refresh token from the response.
+  /// Presenting a consumed token again fails with 401 and triggers the
+  /// [JwtService.onRefreshTokenReuse] callback (a token-theft signal).
   Future<TokenResponse> refresh(String refreshToken) async {
     final payload = await _jwtService.verifyRefreshToken(refreshToken);
     if (payload == null) {
       throw const ApiException(401, 'Invalid or expired refresh token');
     }
 
-    final newAccessToken = _jwtService.generateAccessToken(
+    final pair = _jwtService.generateTokenPair(
       claims: {
         'sub': payload['sub'],
         'email': payload['email'] ?? '',
@@ -48,16 +54,29 @@ class AuthService {
     );
 
     return TokenResponse(
-      accessToken: newAccessToken,
-      refreshToken: refreshToken,
+      accessToken: pair.accessToken,
+      refreshToken: pair.refreshToken,
     );
   }
 
-  /// Revokes [token] — it will be rejected by [authMiddleware] on all future
-  /// requests until the token naturally expires.
+  /// Revokes the access token (and, when provided, the refresh token) — they
+  /// will be rejected by [authMiddleware] and [JwtService.verifyRefreshToken]
+  /// on all future requests until they naturally expire.
   ///
-  /// The revoked JTI is stored in the [TokenStore] configured in main.dart.
+  /// [JwtService.revokeToken] verifies each token's signature before revoking
+  /// and returns `false` for tokens that fail verification.
+  ///
+  /// The revoked JTIs are stored in the [TokenStore] configured in main.dart.
   /// Switch from [InMemoryTokenStore] to a Redis or database-backed store for
-  /// multi-instance deployments.
-  Future<void> logout(String token) => _jwtService.revokeToken(token);
+  /// multi-instance deployments (extend [TokenStore] and override
+  /// `revokeIfActive` with an atomic operation, e.g. Redis `SET NX EX`).
+  Future<void> logout({
+    required String accessToken,
+    String? refreshToken,
+  }) async {
+    await _jwtService.revokeToken(accessToken);
+    if (refreshToken != null) {
+      await _jwtService.revokeToken(refreshToken);
+    }
+  }
 }

--- a/lib/templates/auth_service_test.dart.tmpl
+++ b/lib/templates/auth_service_test.dart.tmpl
@@ -8,11 +8,14 @@ void main() {
   late AuthService authService;
 
   setUp(() {
+    // A TokenStore is required for revocation (logout) and for single-use
+    // refresh-token rotation.
     jwtService = JwtService(
       accessTokenSecret: 'test-access-secret-key',
       refreshTokenSecret: 'test-refresh-secret-key',
       issuer: 'test',
       audience: 'test-users',
+      tokenStore: InMemoryTokenStore(),
     );
     authService = AuthService(jwtService: jwtService);
   });
@@ -37,7 +40,7 @@ void main() {
       );
     });
 
-    test('refresh with valid token returns new access token', () async {
+    test('refresh with valid token returns a full new token pair', () async {
       final dto = LoginDTO(
         username: 'admin@example.com',
         password: 'password',
@@ -45,6 +48,23 @@ void main() {
       final tokens = authService.login(dto);
       final refreshed = await authService.refresh(tokens.refreshToken);
       expect(refreshed.accessToken, isNotEmpty);
+      expect(refreshed.refreshToken, isNotEmpty);
+      // Rotation: the presented refresh token is consumed and a new one issued.
+      expect(refreshed.refreshToken, isNot(equals(tokens.refreshToken)));
+    });
+
+    test('refresh tokens are single-use — reuse throws 401', () async {
+      final dto = LoginDTO(
+        username: 'admin@example.com',
+        password: 'password',
+      );
+      final tokens = authService.login(dto);
+      await authService.refresh(tokens.refreshToken);
+      expect(
+        () => authService.refresh(tokens.refreshToken),
+        throwsA(isA<ApiException>()
+            .having((e) => e.statusCode, 'statusCode', 401)),
+      );
     });
 
     test('refresh with invalid token throws 401', () async {

--- a/lib/templates/bootstrap.dart.tmpl
+++ b/lib/templates/bootstrap.dart.tmpl
@@ -40,8 +40,11 @@ DartAPI createApp(AppConfig config, {DartApiDB? db}) {
   );
 
   // ── Auth ───────────────────────────────────────────────────────────────────
-  // InMemoryTokenStore keeps revoked JTIs in-process.
-  // Swap for a Redis-backed store in multi-instance or persistent deployments.
+  // InMemoryTokenStore keeps revoked JTIs in-process. For multi-instance or
+  // persistent deployments, extend TokenStore (it is a base class, not an
+  // interface) with a Redis/database backend and override revokeIfActive
+  // with an atomic operation (e.g. Redis `SET key 1 NX EX ttl`) so refresh
+  // rotation stays race-free across processes.
   app.register<InMemoryTokenStore>((_) => InMemoryTokenStore());
   app.register<JwtService>(
     (r) => JwtService(
@@ -50,6 +53,15 @@ DartAPI createApp(AppConfig config, {DartApiDB? db}) {
       issuer: '{{projectName}}',
       audience: '{{projectName}}-users',
       tokenStore: r.get<InMemoryTokenStore>(),
+      // Fires when an already-consumed refresh token is presented again —
+      // the classic token-theft signal (either an attacker or the real user
+      // used it first; the other party's attempt lands here). Respond by
+      // terminating the whole session, e.g. revoke all tokens for
+      // payload['sub'] and force a fresh login.
+      onRefreshTokenReuse: (payload) async {
+        // ignore: avoid_print
+        print('[security] refresh token reuse detected for sub=${payload['sub']}');
+      },
     ),
   );
 
@@ -59,6 +71,11 @@ DartAPI createApp(AppConfig config, {DartApiDB? db}) {
   app.register<ProductService>((r) => ProductService(repository: r.get<ProductRepository>()));
 
   // ── Middleware ─────────────────────────────────────────────────────────────
+  // Structured JSON request logs; health/metrics probes are not logged.
+  app.configureLogging(
+    format: LogFormat.json,
+    excludePaths: ['/health', '/metrics'],
+  );
   app.enableCompression();
   app.enableBackgroundTasks();
   app.enableTimeout(const Duration(seconds: 30));

--- a/lib/templates/main.dart.tmpl
+++ b/lib/templates/main.dart.tmpl
@@ -71,7 +71,10 @@ Future<void> _startApp(int port, {bool shared = false}) async {
     await db?.close();
   });
 
-  await app.start(port: port, shared: shared);
+  // `address` is configurable — e.g. '127.0.0.1' to bind loopback only.
+  // For a graceful programmatic shutdown (tests, embedding), call
+  // `await app.stop()`; SIGINT/SIGTERM are already handled by start().
+  await app.start(port: port, address: '0.0.0.0', shared: shared);
 }
 
 Map<String, String> _loadEnv() {

--- a/lib/templates/pubspec.yaml.tmpl
+++ b/lib/templates/pubspec.yaml.tmpl
@@ -6,7 +6,7 @@ environment:
   sdk: ^3.7.2
 
 dependencies:
-  dartapi_core: ^0.1.9
+  dartapi_core: ^0.3.0
   dartapi_db: ^0.0.15
   shelf: ^1.4.2
   shelf_web_socket: ^3.0.0

--- a/lib/templates/readme.md.tmpl
+++ b/lib/templates/readme.md.tmpl
@@ -232,13 +232,22 @@ Authorization: Bearer <access_token>
 // Response 200
 {
   "accessToken":  "<new_jwt>",
-  "refreshToken": "<same_refresh_jwt>"
+  "refreshToken": "<new_refresh_jwt>"
 }
 ```
 
+Refresh tokens are **single-use** (rotation): each call consumes the
+presented refresh token and returns a full new pair — store the new
+`refreshToken` from the response. Reusing a consumed refresh token fails
+with `401` and is treated as a token-theft signal
+(`JwtService.onRefreshTokenReuse`).
+
 #### `POST /auth/logout` *(Bearer token required)*
 
-Revokes the access token immediately. Returns `204 No Content`.
+Revokes the access token immediately; requests that present a revoked token
+receive `401 Unauthorized` (with a `WWW-Authenticate: Bearer` header).
+Optionally send `{ "refreshToken": "<refresh_jwt>" }` in the body to revoke
+the refresh token as well. Returns `204 No Content`.
 
 ---
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartapi
 description: DartAPI is a CLI-driven project generator and toolset for building typed REST APIs in Dart.
-version: 0.1.51
+version: 0.1.52
 repository: https://github.com/akashgk/dartapi
 homepage: https://github.com/akashgk/dartapi
 issue_tracker: https://github.com/akashgk/dartapi/issues


### PR DESCRIPTION
Updates every template, generated snippet, and test to match `dartapi_core` 0.2.0/0.3.0.

## Dependency bump
- All generated pubspecs (programmatic builder + `pubspec.yaml.tmpl`) now declare `dartapi_core: ^0.3.0`.

## Auth templates
- **Login** (`auth_service.dart.tmpl`) issues tokens via `jwt.generateTokenPair(claims: ...)` and returns both `pair.accessToken` and `pair.refreshToken`. The deprecated `generateRefreshToken(accessToken: ...)` (security issue, removed in 0.4.0) is gone.
- **Refresh** returns a **full new pair** via `generateTokenPair` — refresh tokens are single-use when a `TokenStore` is configured (`verifyRefreshToken` consumes them atomically), so re-issuing the old token would strand the client.
- **Logout** revokes both the access token and, when the client sends `{"refreshToken": "..."}` in the body, the refresh token (`revokeToken` now verifies signatures and returns `Future<bool>`). The logout route's request schema documents the optional body.
- `onRefreshTokenReuse` is wired in `bootstrap.dart.tmpl` and the generated `main.dart` with a comment explaining it fires when an already-consumed refresh token is presented again (token-theft signal).

## Breaking-behavior accommodations
- Generated auth tests construct `JwtService` with an `InMemoryTokenStore` (required for revocation/rotation) and now assert: rotated (different) refresh token on refresh, 401 on reuse of a consumed token, and dual revocation on logout. No generated tests asserted the old 403 — the generated README already documented 401 and now also mentions the `WWW-Authenticate: Bearer` header.
- `TokenStore` comments updated: it's a base class to **extend**, `revoke()` gained `{Duration? ttl}`, and distributed backends should override `revokeIfActive` with an atomic op (Redis `SET NX EX`).
- No templates use `queryParam<bool>`/`pathParam<bool>`/`header<bool>`, so nothing to change for the stricter bool parsing.

## New DartAPI APIs in generated projects
- `app.configureLogging(format: LogFormat.json, excludePaths: ['/health', '/metrics'])` in the full-scaffold bootstrap (`['/health']` for partial modes).
- `app.start(address: '0.0.0.0', ...)` is explicit, with a comment pointing at `await app.stop()` for graceful programmatic shutdown.

## Fixes surfaced while regenerating
- Partial-mode generated `main.dart` had an `ambiguous_import` error (`AppConfig` from both the project and the `dartapi_core` barrel) — now hidden from the barrel import, matching `bootstrap.dart.tmpl`.
- Dropped the now-`unnecessary_import` of `env_loader.dart` from partial-mode `main.dart`.

## Verification
- CLI: `dart analyze` clean, `dart test` 119/119 passing.
- Scaffolded `--minimal`, `--with=auth`, `--with=auth,db`, `--with=files,ws`, and `--full` projects against a dartapi_core 0.3.0 checkout: `dart analyze --fatal-infos` clean and `dart test` green on all (9 auth tests, 22 tests in db/full variants).
- End-to-end smoke test on a scaffolded `--with=auth` server: login returns a pair, refresh rotates, reuse of a consumed refresh token returns 401 and fires `onRefreshTokenReuse`, logout with body revokes both tokens (204), missing token returns 401 with `WWW-Authenticate: Bearer`, and request logs are structured JSON with `/health` excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DYe2fMSian4nnJDeF8PBAC

---
_Generated by [Claude Code](https://claude.ai/code/session_01DYe2fMSian4nnJDeF8PBAC)_